### PR TITLE
Pass error to catch statement and log out

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,8 +8,8 @@ let username = null;
 
 try {
   username = JSON.parse(fs.readFileSync("config.json", {encoding: "utf8"})).username;
-} catch {
-  console.log(`config.json not found - please press the link button on your Hue bridge and open localhost:${PORT}/createuser in your browser`);
+} catch(err) {
+  console.log(`config.json not found - please press the link button on your Hue bridge and open localhost:${PORT}/createuser in your browser. \n${err}`);
 }
 
 const api = require("./api")(process.argv[2], username);


### PR DESCRIPTION
Hi Maria! I got a syntax error when I ran server.js. 
```
/Users/Natstar/Projects/Hue-Disco/server.js:11
} catch {
        ^

SyntaxError: Unexpected token {
```

This PR adds a catch statement so the error can be handled and logged out :)